### PR TITLE
build: properly check for the staging directory presence

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -200,6 +200,6 @@ endif()
 add_custom_target (deb 
 	dpkg-buildpackage "-rfakeroot")
 
-if (-z $LUNA_STAGING)
+if (NOT IS_DIRECTORY "${LUNA_STAGING}/")
 	install(FILES pbnjson.pc DESTINATION /usr/local/webos/usr/share/pkgconfig/)
 endif()


### PR DESCRIPTION
Fixes regression introduced in 6ec913df3d1f487927f644f01dcce040737ff553
